### PR TITLE
Removed TODO

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-// TODO: fix bug with common-ignore module and update tests
 // A babel plugin that lists imports
 import babel from '@babel/core'
 import EventEmitter from 'eventemitter3'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-list-imports",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-list-imports",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Lists the files imported by a ESModule file.",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
The 
```js
// TODO: 
```
was accidentally published, but the TODO is actually done, so we just need to remove it. This would be a semver patch.